### PR TITLE
[WIP] Add charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,8 @@
         "tailwindcss": "^3.0.22",
         "textversionjs": "^1.1.3",
         "ts-node": "^10.7.0",
-        "tunnel": "^0.0.6"
+        "tunnel": "^0.0.6",
+        "victory": "^36.3.2"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "^4.2.4",
@@ -3167,6 +3168,89 @@
         "internmap": "^1.0.0"
       }
     },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
     "node_modules/dashify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
@@ -3341,6 +3425,19 @@
       "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5014,6 +5111,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json2csv": {
       "version": "5.0.5",
@@ -33763,6 +33865,11 @@
         "react-dom": "^0.14.7 || ^15.0.0-0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "node_modules/react-hook-form": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.28.0.tgz",
@@ -35268,6 +35375,438 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-36.3.2.tgz",
+      "integrity": "sha512-++LY8hFzhxsWCErN8SMz0WcrhCeueHQz22H3ELzQl4lcDxC1+hyQ1eLm6yGVpfqPG6HROKCRVpxZhE1PiDQFNQ==",
+      "dependencies": {
+        "victory-area": "^36.3.2",
+        "victory-axis": "^36.3.2",
+        "victory-bar": "^36.3.2",
+        "victory-box-plot": "^36.3.2",
+        "victory-brush-container": "^36.3.2",
+        "victory-brush-line": "^36.3.2",
+        "victory-candlestick": "^36.3.2",
+        "victory-canvas": "^36.3.2",
+        "victory-chart": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-create-container": "^36.3.2",
+        "victory-cursor-container": "^36.3.2",
+        "victory-errorbar": "^36.3.2",
+        "victory-group": "^36.3.2",
+        "victory-histogram": "^36.3.2",
+        "victory-legend": "^36.3.2",
+        "victory-line": "^36.3.2",
+        "victory-pie": "^36.3.2",
+        "victory-polar-axis": "^36.3.2",
+        "victory-scatter": "^36.3.2",
+        "victory-selection-container": "^36.3.2",
+        "victory-shared-events": "^36.3.2",
+        "victory-stack": "^36.3.2",
+        "victory-tooltip": "^36.3.2",
+        "victory-voronoi": "^36.3.2",
+        "victory-voronoi-container": "^36.3.2",
+        "victory-zoom-container": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.3.2.tgz",
+      "integrity": "sha512-Cc5eu1LUDQdYMATNX8u6K+Dlbcr83bqXP1dHsKz2i2fib2cus491YnBbxvS39kW8bt7hCKjdmX0uEFdFyo1KSg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.3.2.tgz",
+      "integrity": "sha512-uhCRiM3VPrJvSGQq3qaneC2906rFbUyndpQkoNLgY7Igp5kQaHMRFwp6xMjhay58Etr7qbmEFslpmQ0E3nedlQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.3.2.tgz",
+      "integrity": "sha512-fM9M05UAukwMKGyKwALB43T3xbIwT/9HR3FsdGr7LLEk+LWXxM4oBchyCE9TaCf9/6EvW8fmu6TEjcCr1Vd/tw==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.3.2.tgz",
+      "integrity": "sha512-kC9iXh21+UfxNfNMkjx986b3FXpvIQ06c/OLX/qVzowXUgPySMnk/tSkybFKg1R4ncZuAxD0Xl03fAoysYeCZw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-box-plot/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/victory-brush-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.3.2.tgz",
+      "integrity": "sha512-n8gDLtGbil1ylk3vELX0ZicNcyI1mFEzt1+JtjZzMhPlu45XOF2O492rMksD5d69cDgXzQ87QUOF0HhTP6UOTg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.3.2.tgz",
+      "integrity": "sha512-aYTBcJV94A1p35ZExuUWnptg7KiLwGSU9cVU7SJTRZ06L2VyhvH8UTP+3m0Z/liHeSBV0WWJ+tltcDBufCjpHQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.3.2.tgz",
+      "integrity": "sha512-jrr8OSJnoIDCLshXXGg43GVhn5f5FrgFvSFMZYdZ2zKByF02Zxi5A4v6aKYMZ+V4hvoAlqtE+AsQgqzIJiKY8g==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.3.2.tgz",
+      "integrity": "sha512-j2nONFCrEzhGD+7KKzfLmBwI5PcQ+WXNiTbqTxnIuYad1c68inQjRByI4703HiYNIIPb1FryJ47sQgfLMich8w==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.3.2.tgz",
+      "integrity": "sha512-tSyf1wTVmVoXPnKlXCoK9ldOQ6WRtoJ052fDLFa/Ws12dy7X9Oxz6JlZa968nsjyLxs0bkJeA74sjvJAzhFFCQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-polar-axis": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.3.2.tgz",
+      "integrity": "sha512-p7SRqW7KqRJb+/mgjaTtZFSjM86llH0+vnabnUkVE7YE7ZwOiB5vhC1iPMv2d9BeNwyUs9ahO+TD7en3Mg3UUg==",
+      "dependencies": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.3.2.tgz",
+      "integrity": "sha512-4BE269o9ch6AUv9wyaKx7usaUPXx5prB7nCbmkNTkxUKFHyk7FC/JuXwhfSjebiAuoU/4KWWhd0pzLLtW9XLsw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-cursor-container": "^36.3.2",
+        "victory-selection-container": "^36.3.2",
+        "victory-voronoi-container": "^36.3.2",
+        "victory-zoom-container": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.3.2.tgz",
+      "integrity": "sha512-XCIJ1pOuMltjn4LD73RcykctuvyEHH9oPV5qwN85GUv1QNXuYgtBJ+8DtqM8hqnPYK4TuTqBbYb3UFnmqoKi8g==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.3.2.tgz",
+      "integrity": "sha512-eA52LHYA8hnP3BydmZbnjogkmzmG8BWZU45iRXvA53XjLwd4/W2hIJ36ZBByW9ut1f9oxUijSvf0yMmolsD5tA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.3.2.tgz",
+      "integrity": "sha512-P7iu63VZzXmpOGEPwHRvY8k5lx1EgTFssh0rlSGOgzTM2I6V3LAR9hIzXs9I4iQfrkEU8W1DAOEkT3IDTNfeyQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.3.2.tgz",
+      "integrity": "sha512-dN2V/jCOUrQy/XHe5HnJ6BgH6S3LT5eDniY+EPiMtbXNBPWkFRiL2YjR28c0Bn2pVfHvamiMti7AhQA7/P6kVw==",
+      "dependencies": {
+        "d3-array": "~2.3.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^36.3.2",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-histogram/node_modules/d3-array": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.3.3.tgz",
+      "integrity": "sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ=="
+    },
+    "node_modules/victory-legend": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.3.2.tgz",
+      "integrity": "sha512-hnHuwFyaLBbG3AsAt7vhp9GfSSut2Q77WX/AYYifsyOkECtpH7p8/oW+sYmDp51STbeOoOmgBQvRz9rqhjRkhQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.3.2.tgz",
+      "integrity": "sha512-ZiZgpbzomv5oqxeNNXIoDtUvwUDhYMZQRT/pi1+UplqcPyN5VWy78cdgtE7uJeIpk+phoOxGRD1VYPiNeVpuqg==",
+      "dependencies": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.3.2.tgz",
+      "integrity": "sha512-Au45U+i3KwVZLDe4qydT9OpAZBr7Kln50SZEGFX3QVQPw4fqDZnOHt1cw9dIL81DcZyM8ZNFgg1Q6AM4q6mdcg==",
+      "dependencies": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.3.2.tgz",
+      "integrity": "sha512-HC1U3Zzl9lfi0eHREuunmYTJTe+CLiSXo2nF09t1ksMnRmklJg15/+Zo870OzihWujGiJf+6nODjnD+6MsMnCQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.3.2.tgz",
+      "integrity": "sha512-DY6pMccY8OX5ijjTyTkJbudKlcFe34ECiHdEH+SHYJgvQQL5/9IJ5hcFOeyyieUxZiu4nFT1P14+Y436YZCykA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.3.2.tgz",
+      "integrity": "sha512-upKgAMwIZIME6VHEeZZhd7KYp4XVis4tST0+6Pevpt4RIO6R+6Rl3bV9t8EfVVE2SdqWL5vra0+HtaVVRpqAIQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.3.2.tgz",
+      "integrity": "sha512-8ME0LRT2B7j4VGqYhKtq1A8Npnkn65r2K9VpIFulePpmA2+KlEHey2lxqjns4lW4DoaeAMBF45kJUzwwa5twtQ==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.3.2.tgz",
+      "integrity": "sha512-ySxzU9H7peNyVgYdkvHgqN63A4PV9efHxq6SnMvxc36B4VZTwT3N4Qrbi+MGsJ5LhQ7R2Q2eH3mBqXPYrNfiEg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.3.2.tgz",
+      "integrity": "sha512-wH+3Qpg/MMLeJ0Z+/GJpSOPldxczP5g3VcdE/p9JAxUwlL3bC6oWA//HoZO+TqlQSaIg8dGcaKgFoh7c8avCQQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.3.2.tgz",
+      "integrity": "sha512-x3Nzk2wwyJixDon1Cw/TXdIKxdAliErlyglgMo+/nBFEulMTl0rDc6zWuyNWCD/MelkQ3O0jQqTORtpBKcJ86w==",
+      "dependencies": {
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.3.2.tgz",
+      "integrity": "sha512-lV7fx3NWiHa40wY0TIKgIlrmj+KIsI9HeYpO7D13F2ooGTPvUlNE+7ZkBzmDT2KQ5wmXMV2u3lcaAWWVlLrc4Q==",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-tooltip": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.3.2.tgz",
+      "integrity": "sha512-xE0ds97gS07iKXaEDCiMWVE/IyxK4fjhaY7Mgr928qNVABk7e8VATguNstQKgu7UaoS5tI8tRxNLaXhHfBHoQQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -37611,6 +38150,91 @@
         "internmap": "^1.0.0"
       }
     },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        }
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
     "dashify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
@@ -37729,6 +38353,19 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
       "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
       "dev": true
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "requires": {
+        "delaunator": "^4.0.0"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -38892,6 +39529,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2csv": {
       "version": "5.0.5",
@@ -60419,6 +61061,11 @@
         "classnames": "^2.2.3"
       }
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-hook-form": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.28.0.tgz",
@@ -61440,6 +62087,358 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
+      }
+    },
+    "victory": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-36.3.2.tgz",
+      "integrity": "sha512-++LY8hFzhxsWCErN8SMz0WcrhCeueHQz22H3ELzQl4lcDxC1+hyQ1eLm6yGVpfqPG6HROKCRVpxZhE1PiDQFNQ==",
+      "requires": {
+        "victory-area": "^36.3.2",
+        "victory-axis": "^36.3.2",
+        "victory-bar": "^36.3.2",
+        "victory-box-plot": "^36.3.2",
+        "victory-brush-container": "^36.3.2",
+        "victory-brush-line": "^36.3.2",
+        "victory-candlestick": "^36.3.2",
+        "victory-canvas": "^36.3.2",
+        "victory-chart": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-create-container": "^36.3.2",
+        "victory-cursor-container": "^36.3.2",
+        "victory-errorbar": "^36.3.2",
+        "victory-group": "^36.3.2",
+        "victory-histogram": "^36.3.2",
+        "victory-legend": "^36.3.2",
+        "victory-line": "^36.3.2",
+        "victory-pie": "^36.3.2",
+        "victory-polar-axis": "^36.3.2",
+        "victory-scatter": "^36.3.2",
+        "victory-selection-container": "^36.3.2",
+        "victory-shared-events": "^36.3.2",
+        "victory-stack": "^36.3.2",
+        "victory-tooltip": "^36.3.2",
+        "victory-voronoi": "^36.3.2",
+        "victory-voronoi-container": "^36.3.2",
+        "victory-zoom-container": "^36.3.2"
+      }
+    },
+    "victory-area": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.3.2.tgz",
+      "integrity": "sha512-Cc5eu1LUDQdYMATNX8u6K+Dlbcr83bqXP1dHsKz2i2fib2cus491YnBbxvS39kW8bt7hCKjdmX0uEFdFyo1KSg==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-axis": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.3.2.tgz",
+      "integrity": "sha512-uhCRiM3VPrJvSGQq3qaneC2906rFbUyndpQkoNLgY7Igp5kQaHMRFwp6xMjhay58Etr7qbmEFslpmQ0E3nedlQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-bar": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.3.2.tgz",
+      "integrity": "sha512-fM9M05UAukwMKGyKwALB43T3xbIwT/9HR3FsdGr7LLEk+LWXxM4oBchyCE9TaCf9/6EvW8fmu6TEjcCr1Vd/tw==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-box-plot": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.3.2.tgz",
+      "integrity": "sha512-kC9iXh21+UfxNfNMkjx986b3FXpvIQ06c/OLX/qVzowXUgPySMnk/tSkybFKg1R4ncZuAxD0Xl03fAoysYeCZw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        }
+      }
+    },
+    "victory-brush-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.3.2.tgz",
+      "integrity": "sha512-n8gDLtGbil1ylk3vELX0ZicNcyI1mFEzt1+JtjZzMhPlu45XOF2O492rMksD5d69cDgXzQ87QUOF0HhTP6UOTg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-brush-line": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.3.2.tgz",
+      "integrity": "sha512-aYTBcJV94A1p35ZExuUWnptg7KiLwGSU9cVU7SJTRZ06L2VyhvH8UTP+3m0Z/liHeSBV0WWJ+tltcDBufCjpHQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-candlestick": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.3.2.tgz",
+      "integrity": "sha512-jrr8OSJnoIDCLshXXGg43GVhn5f5FrgFvSFMZYdZ2zKByF02Zxi5A4v6aKYMZ+V4hvoAlqtE+AsQgqzIJiKY8g==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-canvas": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.3.2.tgz",
+      "integrity": "sha512-j2nONFCrEzhGD+7KKzfLmBwI5PcQ+WXNiTbqTxnIuYad1c68inQjRByI4703HiYNIIPb1FryJ47sQgfLMich8w==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-chart": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.3.2.tgz",
+      "integrity": "sha512-tSyf1wTVmVoXPnKlXCoK9ldOQ6WRtoJ052fDLFa/Ws12dy7X9Oxz6JlZa968nsjyLxs0bkJeA74sjvJAzhFFCQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-polar-axis": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      }
+    },
+    "victory-core": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.3.2.tgz",
+      "integrity": "sha512-p7SRqW7KqRJb+/mgjaTtZFSjM86llH0+vnabnUkVE7YE7ZwOiB5vhC1iPMv2d9BeNwyUs9ahO+TD7en3Mg3UUg==",
+      "requires": {
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
+      }
+    },
+    "victory-create-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.3.2.tgz",
+      "integrity": "sha512-4BE269o9ch6AUv9wyaKx7usaUPXx5prB7nCbmkNTkxUKFHyk7FC/JuXwhfSjebiAuoU/4KWWhd0pzLLtW9XLsw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^36.3.2",
+        "victory-core": "^36.3.2",
+        "victory-cursor-container": "^36.3.2",
+        "victory-selection-container": "^36.3.2",
+        "victory-voronoi-container": "^36.3.2",
+        "victory-zoom-container": "^36.3.2"
+      }
+    },
+    "victory-cursor-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.3.2.tgz",
+      "integrity": "sha512-XCIJ1pOuMltjn4LD73RcykctuvyEHH9oPV5qwN85GUv1QNXuYgtBJ+8DtqM8hqnPYK4TuTqBbYb3UFnmqoKi8g==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-errorbar": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.3.2.tgz",
+      "integrity": "sha512-eA52LHYA8hnP3BydmZbnjogkmzmG8BWZU45iRXvA53XjLwd4/W2hIJ36ZBByW9ut1f9oxUijSvf0yMmolsD5tA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-group": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.3.2.tgz",
+      "integrity": "sha512-P7iu63VZzXmpOGEPwHRvY8k5lx1EgTFssh0rlSGOgzTM2I6V3LAR9hIzXs9I4iQfrkEU8W1DAOEkT3IDTNfeyQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      }
+    },
+    "victory-histogram": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.3.2.tgz",
+      "integrity": "sha512-dN2V/jCOUrQy/XHe5HnJ6BgH6S3LT5eDniY+EPiMtbXNBPWkFRiL2YjR28c0Bn2pVfHvamiMti7AhQA7/P6kVw==",
+      "requires": {
+        "d3-array": "~2.3.0",
+        "d3-scale": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-bar": "^36.3.2",
+        "victory-core": "^36.3.2"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.3.3.tgz",
+          "integrity": "sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ=="
+        }
+      }
+    },
+    "victory-legend": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.3.2.tgz",
+      "integrity": "sha512-hnHuwFyaLBbG3AsAt7vhp9GfSSut2Q77WX/AYYifsyOkECtpH7p8/oW+sYmDp51STbeOoOmgBQvRz9rqhjRkhQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-line": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.3.2.tgz",
+      "integrity": "sha512-ZiZgpbzomv5oqxeNNXIoDtUvwUDhYMZQRT/pi1+UplqcPyN5VWy78cdgtE7uJeIpk+phoOxGRD1VYPiNeVpuqg==",
+      "requires": {
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-pie": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.3.2.tgz",
+      "integrity": "sha512-Au45U+i3KwVZLDe4qydT9OpAZBr7Kln50SZEGFX3QVQPw4fqDZnOHt1cw9dIL81DcZyM8ZNFgg1Q6AM4q6mdcg==",
+      "requires": {
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-polar-axis": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.3.2.tgz",
+      "integrity": "sha512-HC1U3Zzl9lfi0eHREuunmYTJTe+CLiSXo2nF09t1ksMnRmklJg15/+Zo870OzihWujGiJf+6nODjnD+6MsMnCQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-scatter": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.3.2.tgz",
+      "integrity": "sha512-DY6pMccY8OX5ijjTyTkJbudKlcFe34ECiHdEH+SHYJgvQQL5/9IJ5hcFOeyyieUxZiu4nFT1P14+Y436YZCykA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-selection-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.3.2.tgz",
+      "integrity": "sha512-upKgAMwIZIME6VHEeZZhd7KYp4XVis4tST0+6Pevpt4RIO6R+6Rl3bV9t8EfVVE2SdqWL5vra0+HtaVVRpqAIQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-shared-events": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.3.2.tgz",
+      "integrity": "sha512-8ME0LRT2B7j4VGqYhKtq1A8Npnkn65r2K9VpIFulePpmA2+KlEHey2lxqjns4lW4DoaeAMBF45kJUzwwa5twtQ==",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-stack": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.3.2.tgz",
+      "integrity": "sha512-ySxzU9H7peNyVgYdkvHgqN63A4PV9efHxq6SnMvxc36B4VZTwT3N4Qrbi+MGsJ5LhQ7R2Q2eH3mBqXPYrNfiEg==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-shared-events": "^36.3.2"
+      }
+    },
+    "victory-tooltip": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.3.2.tgz",
+      "integrity": "sha512-wH+3Qpg/MMLeJ0Z+/GJpSOPldxczP5g3VcdE/p9JAxUwlL3bC6oWA//HoZO+TqlQSaIg8dGcaKgFoh7c8avCQQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-voronoi": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.3.2.tgz",
+      "integrity": "sha512-x3Nzk2wwyJixDon1Cw/TXdIKxdAliErlyglgMo+/nBFEulMTl0rDc6zWuyNWCD/MelkQ3O0jQqTORtpBKcJ86w==",
+      "requires": {
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
+      }
+    },
+    "victory-voronoi-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.3.2.tgz",
+      "integrity": "sha512-lV7fx3NWiHa40wY0TIKgIlrmj+KIsI9HeYpO7D13F2ooGTPvUlNE+7ZkBzmDT2KQ5wmXMV2u3lcaAWWVlLrc4Q==",
+      "requires": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^36.3.2",
+        "victory-tooltip": "^36.3.2"
+      }
+    },
+    "victory-zoom-container": {
+      "version": "36.3.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.3.2.tgz",
+      "integrity": "sha512-xE0ds97gS07iKXaEDCiMWVE/IyxK4fjhaY7Mgr928qNVABk7e8VATguNstQKgu7UaoS5tI8tRxNLaXhHfBHoQQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.5.8",
+        "victory-core": "^36.3.2"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "tailwindcss": "^3.0.22",
     "textversionjs": "^1.1.3",
     "ts-node": "^10.7.0",
-    "tunnel": "^0.0.6"
+    "tunnel": "^0.0.6",
+    "victory": "^36.3.2"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^4.2.4",

--- a/src/pages/charts/embed/[id].tsx
+++ b/src/pages/charts/embed/[id].tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, NextPage } from "next";
+import Error from "next/error";
+
+import { DashboardItem } from "../../../backend/dashboards";
+import { DisplayForecasts } from "../../../web/display/DisplayForecasts";
+import { FrontendForecast } from "../../../web/platforms";
+import { getDashboardForecastsByDashboardId } from "../../../web/worker/getDashboardForecasts";
+import { reqToBasePath } from "../../../web/utils";
+
+interface Props {
+  dashboardForecasts: FrontendForecast[];
+  dashboardItem: DashboardItem;
+  numCols?: number;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  const dashboardId = context.query.id as string;
+  const numCols = Number(context.query.numCols);
+
+  const { dashboardItem, dashboardForecasts } =
+    await getDashboardForecastsByDashboardId({
+      dashboardId,
+      basePath: reqToBasePath(context.req), // required on server side to find the API endpoint
+    });
+
+  if (!dashboardItem) {
+    context.res.statusCode = 404;
+  }
+
+  return {
+    props: {
+      dashboardForecasts,
+      dashboardItem,
+      numCols: !numCols ? null : numCols < 5 ? numCols : 4,
+    },
+  };
+};
+
+const EmbedDashboardPage: NextPage<Props> = ({
+  dashboardForecasts,
+  dashboardItem,
+  numCols,
+}) => {
+  if (!dashboardItem) {
+    return <Error statusCode={404} />;
+  }
+
+  return (
+    <div className="mb-4 mt-3 flex flex-row justify-left items-center">
+      <div className="mx-2 place-self-left">
+        <div
+          className={`grid grid-cols-${numCols || 1} sm:grid-cols-${
+            numCols || 1
+          } md:grid-cols-${numCols || 2} lg:grid-cols-${
+            numCols || 3
+          } gap-4 mb-6`}
+        >
+          <DisplayForecasts
+            results={dashboardForecasts}
+            numDisplay={dashboardForecasts.length}
+            showIdToggle={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmbedDashboardPage;

--- a/src/pages/charts/index.tsx
+++ b/src/pages/charts/index.tsx
@@ -1,0 +1,51 @@
+import axios from "axios";
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+
+import { DashboardCreator } from "../../web/display/DashboardCreator";
+import { InfoBox } from "../../web/display/InfoBox";
+
+import { Layout } from "../../web/display/Layout";
+import { LineHeader } from "../../web/display/LineHeader";
+
+const DashboardsPage: NextPage = () => {
+  const router = useRouter();
+
+  const handleSubmit = async (data) => {
+    // Send to server to create
+    // Get back the id
+    let response = await axios({
+      url: "/api/create-dashboard-from-ids",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: JSON.stringify(data),
+    }).then((res) => res.data);
+    await router.push(`/dashboards/view/${response.dashboardId}`);
+  };
+
+  return (
+    <Layout page="dashboard">
+      <div className="flex flex-col my-8 space-y-8">
+        <LineHeader>Charts!</LineHeader>
+
+        <div className="self-center">{""}</div>
+        <div className="max-w-2xl self-center">
+          <InfoBox>
+            This is an under-construction endpoint to display charts. Go to
+            metaforecast.org/charts/view/[id] to find the chart for a particular
+            question.
+          </InfoBox>
+        </div>
+        <div className="max-w-2xl self-center">
+          <InfoBox>
+            You can find the necessary ids by toggling the advanced options in
+            the search, or by visiting{" "}
+            <a href="/api/all-forecasts">/api/all-forecasts</a>
+          </InfoBox>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default DashboardsPage;

--- a/src/pages/charts/view/[id].tsx
+++ b/src/pages/charts/view/[id].tsx
@@ -45,8 +45,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
 const Chart: NextPage<Props> = ({ question, history }) => {
   return (
     <Layout page={"chart"}>
-      <div className="w-6/12 mb-4 mt-8 flex flex-row justify-center items-center bg-white">
-        <HistoryChart question={question} history={history} />
+      <div className="flex flex-col w-12/12 mb-4 mt-8 justify-center items-center self-center">
+        <div className="grid bg-white p-10">
+          <HistoryChart question={question} history={history} />
+        </div>
       </div>
     </Layout>
   );

--- a/src/pages/charts/view/[id].tsx
+++ b/src/pages/charts/view/[id].tsx
@@ -56,12 +56,12 @@ async function fakeGetHistoryQuestionById(id) {
     timestamp: `2022-04-${`0${x + 1}`.slice(-2)}T13:09:13.000Z`,
     options: [
       {
-        name: "X",
+        name: "Yes",
         type: "PROBABILITY",
         probability: 0.0351 + Math.abs(Math.sin(3 * x)) / 2,
       },
       {
-        name: "Y",
+        name: "No",
         type: "PROBABILITY",
         probability: 0.9649 - Math.abs(Math.sin(3 * x)) / 2,
       },

--- a/src/pages/charts/view/[id].tsx
+++ b/src/pages/charts/view/[id].tsx
@@ -53,17 +53,17 @@ async function fakeGetHistoryQuestionById(id) {
   let l = 30;
 
   let history = Array.from(Array(l).keys()).map((x) => ({
-    timestamp: `2022-04-${`0${x}`.slice(-2)}T13:09:13.000Z`,
+    timestamp: `2022-04-${`0${x + 1}`.slice(-2)}T13:09:13.000Z`,
     options: [
       {
-        name: "Yes",
+        name: "X",
         type: "PROBABILITY",
-        probability: 0.0351 + Math.abs(Math.sin(3 * x)),
+        probability: 0.0351 + Math.abs(Math.sin(3 * x)) / 2,
       },
       {
-        name: "No",
+        name: "Y",
         type: "PROBABILITY",
-        probability: 0.9649 - Math.abs(Math.sin(3 * x)),
+        probability: 0.9649 - Math.abs(Math.sin(3 * x)) / 2,
       },
     ],
   }));

--- a/src/pages/charts/view/[id].tsx
+++ b/src/pages/charts/view/[id].tsx
@@ -15,29 +15,82 @@ interface Props {
   history: number[];
 }
 
+async function fakeGetQuestionByIdBinary(id) {
+  return {
+    id: "infer-958",
+    title:
+      "In the next six months, will U.S. and China announce the establishment of an ongoing bilateral dialog mechanism that includes discussions of emerging technologies?",
+    url: "https://www.infer-pub.com/questions/958-in-the-next-six-months-will-u-s-and-china-announce-the-establishment-of-an-ongoing-bilateral-dialog-mechanism-that-includes-discussions-of-emerging-technologies",
+    platform: "infer",
+    platformLabel: "Infer",
+    description:
+      "The National Security Commission on Artificial Intelligence argues that establishing a regular, high-level diplomatic dialogue with China about artificial intelligence is key to developing and executing a strategy on how to remain competitive and safe as AI technology changes the world ([NSCAI Report Chapter 9](https://reports.nscai.gov/final-report/chapter-9/)). Examples of ongoing bilateral dialog mechanisms are the [Strategic and Economic Dialog](https://china.usc.edu/statements-obama-hu-bilateral-meeting-april-1-2009) under President Obama ([National Committee on American Foreign Policy—NCAFP](https://www.ncafp.org)), the [Comprehensive Economic Dialog](https://www.deccanherald.com/content/605333/trump-xi-establish-us-china.html) under President Trump, and the [Strategic Economic Dialog](https://www.treasury.gov/press-center/press-releases/pages/hp107.aspx) under President George W. Bush. Emerging technologies (e.g. artificial intelligence, quantum computing, and biotech) must be a core component of the dialog structure. \n",
+    options: [
+      {
+        name: "Yes",
+        type: "PROBABILITY",
+        probability: 0.0351,
+      },
+      {
+        name: "No",
+        type: "PROBABILITY",
+        probability: 0.9649,
+      },
+    ],
+    timestamp: "2022-04-19T13:09:13.000Z",
+    stars: 2,
+    qualityindicators: {
+      stars: 2,
+      numforecasts: 164,
+      comments_count: 171,
+      numforecasters: 64,
+    },
+    extra: [],
+  };
+}
+
+async function fakeGetHistoryQuestionById(id) {
+  let l = 30;
+
+  let history = Array.from(Array(l).keys()).map((x) => ({
+    timestamp: `2022-04-${`0${x}`.slice(-2)}T13:09:13.000Z`,
+    options: [
+      {
+        name: "Yes",
+        type: "PROBABILITY",
+        probability: 0.0351 + Math.abs(Math.sin(3 * x)),
+      },
+      {
+        name: "No",
+        type: "PROBABILITY",
+        probability: 0.9649 - Math.abs(Math.sin(3 * x)),
+      },
+    ],
+  }));
+  return history;
+}
+
 export const getServerSideProps: GetServerSideProps<Props> = async (
   context
 ) => {
   let urlQuery = context.query; // this is an object, not a string which I have to parse!!
 
   let initialQueryParameters = {
-    query: "test",
-    starsThreshold: 2,
-    forecastsThreshold: 0,
-    forecastingPlatforms: platforms.map((platform) => platform.name),
+    id: null,
     ...urlQuery,
   };
 
-  let results: FrontendForecast[] = [];
-  if (initialQueryParameters.query != "") {
-    results = await searchAccordingToQueryData(initialQueryParameters, 1);
-    console.log(results);
+  let question: FrontendForecast;
+  let history: any[]; // replace with prop def.
+  if (initialQueryParameters.id != null) {
+    question = await fakeGetQuestionByIdBinary(initialQueryParameters.id);
+    history = await fakeGetHistoryQuestionById(initialQueryParameters.id);
   }
 
   return {
     props: {
-      question: results[0] || null,
-      history: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      question: question,
+      history: history,
     },
   };
 };
@@ -46,12 +99,59 @@ const Chart: NextPage<Props> = ({ question, history }) => {
   return (
     <Layout page={"chart"}>
       <div className="flex flex-col w-12/12 mb-4 mt-8 justify-center items-center self-center">
-        <div className="grid bg-white p-10">
-          <HistoryChart question={question} history={history} />
-        </div>
+        <HistoryChart question={question} history={history} />
       </div>
     </Layout>
   );
 };
 
 export default Chart;
+
+/*
+
+async function fakeGetQuestionByIdMultipleOptions(id) {
+  return {
+    id: "infer-954",
+    title:
+      "Will the U.S. Congress pass a tax credit for semiconductor manufacturing or design before 1 January 2023?",
+    url: "https://www.infer-pub.com/questions/954-will-the-u-s-congress-pass-a-tax-credit-for-semi-conductor-manufacturing-or-design-before-1-january-2023",
+    platform: "infer",
+    platformLabel: "Infer",
+    description:
+      "The National Security Commission on Artificial Intelligence identified developments in micro-electronics and semiconductors as critical to the United States&#39; competitive strategy ([NSCAI Chapter 13](https://reports.nscai.gov/final-report/chapter-13/)). The Facilitating American-Built Semiconductors Act would offer an investment tax credit for investments in semiconductor manufacturing ([Congress.Gov](https://www.congress.gov/bill/117th-congress/senate-bill/2107/text?r=68&amp;s=1), [Senate Finance](https://www.finance.senate.gov/chairmans-news/wyden-crapo-cornyn-warner-daines-stabenow-introduce-bill-to-boost-domestic-manufacturing-of-semiconductors)). Tech companies are lobbying not only for passage, but for expansion of the credit to cover semiconductor design as well ([Bloomberg](https://www.bloomberg.com/news/articles/2021-12-01/corporate-leaders-push-congress-to-speed-aid-for-semiconductors), [SIA](https://www.semiconductors.org/sia-applauds-senate-introduction-of-fabs-act/)).\n",
+    options: [
+      {
+        name: "Yes, for both manufacturing and design ",
+        type: "PROBABILITY",
+        probability: 0.4129,
+      },
+      {
+        name: "Yes, for only manufacturing",
+        type: "PROBABILITY",
+        probability: 0.3103,
+      },
+      {
+        name: "Yes, for only design",
+        type: "PROBABILITY",
+        probability: 0.0235,
+      },
+      {
+        name: "No",
+        type: "PROBABILITY",
+        probability: 0.2533,
+      },
+    ],
+    timestamp: "2022-04-19T13:09:21.000Z",
+    stars: 2,
+    qualityindicators: {
+      stars: 2,
+      numforecasts: 156,
+      comments_count: 168,
+      numforecasters: 66,
+    },
+    extra: [],
+  };
+}
+
+
+ */

--- a/src/pages/charts/view/[id].tsx
+++ b/src/pages/charts/view/[id].tsx
@@ -1,0 +1,55 @@
+/* Imports */
+
+import { GetServerSideProps, NextPage } from "next";
+import { Layout } from "../../../web/display/Layout";
+
+import React from "react";
+
+import { platforms } from "../../../backend/platforms";
+import { HistoryChart } from "../../../web/display/HistoryChart";
+import { FrontendForecast } from "../../../web/platforms";
+import searchAccordingToQueryData from "../../../web/worker/searchAccordingToQueryData";
+
+interface Props {
+  question: FrontendForecast;
+  history: number[];
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  let urlQuery = context.query; // this is an object, not a string which I have to parse!!
+
+  let initialQueryParameters = {
+    query: "test",
+    starsThreshold: 2,
+    forecastsThreshold: 0,
+    forecastingPlatforms: platforms.map((platform) => platform.name),
+    ...urlQuery,
+  };
+
+  let results: FrontendForecast[] = [];
+  if (initialQueryParameters.query != "") {
+    results = await searchAccordingToQueryData(initialQueryParameters, 1);
+    console.log(results);
+  }
+
+  return {
+    props: {
+      question: results[0] || null,
+      history: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    },
+  };
+};
+
+const Chart: NextPage<Props> = ({ question, history }) => {
+  return (
+    <Layout page={"chart"}>
+      <div className="w-6/12 mb-4 mt-8 flex flex-row justify-center items-center bg-white">
+        <HistoryChart question={question} history={history} />
+      </div>
+    </Layout>
+  );
+};
+
+export default Chart;

--- a/src/web/display/DisplayForecast/index.tsx
+++ b/src/web/display/DisplayForecast/index.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import { FrontendForecast } from "../../platforms";
 import { Card } from "../Card";
 import { ForecastFooter } from "./ForecastFooter";
+import { cleanText } from "../../utils";
 
 const truncateText = (length: number, text: string): string => {
   if (!text) {
@@ -75,24 +76,6 @@ if (!String.prototype.replaceAll) {
     return replaceAll(originalString, pattern, substitute);
   };
 }
-
-const cleanText = (text: string): string => {
-  // Note: should no longer be necessary
-  let textString = !!text ? text : "";
-  textString = textString
-    .replaceAll("] (", "](")
-    .replaceAll(") )", "))")
-    .replaceAll("( [", "([")
-    .replaceAll(") ,", "),")
-    .replaceAll("==", "") // Denotes a title in markdown
-    .replaceAll("Background\n", "")
-    .replaceAll("Context\n", "")
-    .replaceAll("--- \n", "- ")
-    .replaceAll(/\[(.*?)\]\(.*?\)/g, "$1");
-  textString = textString.slice(0, 1) == "=" ? textString.slice(1) : textString;
-  //console.log(textString)
-  return textString;
-};
 
 const primaryForecastColor = (probability: number) => {
   if (probability < 0.03) {

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -33,10 +33,10 @@ const data0 = [
   { date: 9, probability: 0.7 },
 ];
 
-let l = 5;
+let l = 50;
 const data = Array.from(Array(l).keys()).map((x) => ({
   date: x,
-  probability: x / l,
+  probability: Math.abs(Math.sin((5 * x) / l)),
 }));
 
 let getDate = (x) => {
@@ -51,105 +51,79 @@ let dataAsXy = data.map((datum) => ({
 
 export const HistoryChart: React.FC<Props> = ({ question, history }) => {
   return (
-    <VictoryChart
-      domainPadding={20}
-      theme={VictoryTheme.material}
-      height={300}
-      containerComponent={<VictoryVoronoiContainer />}
-      domain={{
-        y: [0, 1],
-      }}
-    >
-      <VictoryGroup
-        color="darkblue"
-        data={dataAsXy}
-        labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
-        labelComponent={
-          <VictoryTooltip
-            pointerLength={0}
-            dy={-12}
-            style={{
-              fontSize: 9,
-              fill: "black",
-              strokeWidth: 0.05,
-            }}
-            flyoutStyle={{
-              stroke: "black",
-              fill: "white",
-            }}
-            flyoutWidth={60}
-            cornerRadius={0}
-            flyoutPadding={7}
-          />
-        }
+    <div className="">
+      <VictoryChart
+        domainPadding={20}
+        theme={VictoryTheme.material}
+        height={400}
+        width={500}
+        containerComponent={<VictoryVoronoiContainer />}
+        domain={{
+          y: [0, 1],
+        }}
       >
-        <VictoryLine />
-        <VictoryScatter size={({ active }) => (active ? 3.75 : 3)} />
-      </VictoryGroup>
-      <VictoryAxis
-        // tickValues specifies both the number of ticks and where
-        // they are placed on the axis
-        tickValues={data.map((datum) => datum.date)}
-        tickCount={10}
-        tickFormat={dataAsXy.map((datum) => datum.x)}
-        style={{
-          grid: { stroke: null, strokeWidth: 0.5 },
-        }}
-        tickLabelComponent={
-          <VictoryLabel
-            dy={0}
-            angle={-30}
-            style={{ fontSize: 7, fill: "gray" }}
-          />
-        }
-      />
-      <VictoryAxis
-        dependentAxis
-        // tickFormat specifies how ticks should be displayed
-        tickFormat={(x) => `${x * 100}%`}
-        style={{
-          grid: { stroke: "#D3D3D3", strokeWidth: 0.5 },
-        }}
-      />
-    </VictoryChart>
+        <VictoryLabel
+          text="Chart Title"
+          x={250}
+          y={25}
+          textAnchor="middle"
+          style={{ fontSize: 20 }}
+        />
+        <VictoryGroup
+          color="darkblue"
+          data={dataAsXy}
+          labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
+          labelComponent={
+            <VictoryTooltip
+              pointerLength={0}
+              dy={-12}
+              style={{
+                fontSize: 16,
+                fill: "black",
+                strokeWidth: 0.05,
+              }}
+              flyoutStyle={{
+                stroke: "black",
+                fill: "white",
+              }}
+              flyoutWidth={110}
+              cornerRadius={0}
+              flyoutPadding={7}
+            />
+          }
+        >
+          <VictoryLine />
+          <VictoryScatter size={({ active }) => (active ? 3.75 : 3)} />
+        </VictoryGroup>
+        <VictoryAxis
+          // tickValues specifies both the number of ticks and where
+          // they are placed on the axis
+          // tickValues={dataAsXy.map((datum) => datum.x)}
+          // tickFormat={dataAsXy.map((datum) => datum.x)}
+          tickCount={7}
+          style={{
+            grid: { stroke: null, strokeWidth: 0.5 },
+          }}
+          tickLabelComponent={
+            <VictoryLabel
+              dy={0}
+              angle={-30}
+              style={{ fontSize: 12, fill: "gray" }}
+            />
+          }
+        />
+        <VictoryAxis
+          dependentAxis
+          // tickFormat specifies how ticks should be displayed
+          tickFormat={(x) => `${x * 100}%`}
+          style={{
+            grid: { stroke: "#D3D3D3", strokeWidth: 0.5 },
+          }}
+          tickLabelComponent={
+            <VictoryLabel dy={0} style={{ fontSize: 12, fill: "gray" }} />
+          }
+        />
+      </VictoryChart>
+    </div>
   );
 };
-
-/*
-    <VictoryChart
-      // domainPadding will add space to each side of VictoryBar to
-      // prevent it from overlapping the axis
-      domainPadding={20}
-      theme={VictoryTheme.material}
-      height={300}
-      title={"Blah"}
-      containerComponent={<VictoryVoronoiContainer />}
-    >
-      <VictoryGroup
-        data={data.map((datum) => ({ x: datum.date, y: datum.probability }))}
-        labels={data.map((datum) => `1%`)}
-        style={{ labels: { fill: "black", fontSize: 10 } }}
-        labelComponent={
-          <VictoryTooltip style={{ fontSize: 10, fill: "black" }} dy={-15} />
-        }
-      >
-        <VictoryLine
-          height={300}
-          width={300}
-          style={{
-            data: { stroke: "#000080" },
-            parent: { border: "1px solid #ccc" },
-          }}
-          domain={{
-            y: [0, 1],
-          }}
-        ></VictoryLine>
-        <VictoryScatter
-          style={{
-            data: { fill: "#000080" },
-          }}
-          size={3}
-        />
-      </VictoryGroup>
-    </VictoryChart>
-*/

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -6,6 +6,7 @@ import {
   VictoryBar,
   VictoryLabel,
   VictoryTooltip,
+  VictoryLegend,
   VictoryLine,
   VictoryScatter,
   VictoryChart,
@@ -34,6 +35,18 @@ const data2 = Array.from(Array(l).keys()).map((x) => ({
   probability: 1 - Math.abs(Math.sin((5 * x) / l)),
 }));
 
+const data3 = Array.from(Array(l).keys()).map((x) => ({
+  date: x,
+  probability: 1 - Math.abs(Math.sin((5 * x + 20) / l)),
+}));
+
+const buildDataset = (n, fn) => {
+  return Array.from(Array(n).keys()).map((x) => ({
+    date: x,
+    probability: fn(x),
+  }));
+};
+
 let getDate = (x) => {
   let date = new Date(x);
   return date.toISOString().slice(5, 10).replaceAll("-", "/");
@@ -45,14 +58,7 @@ let dataAsXy = (data) =>
     y: datum.probability,
   }));
 
-let colors = [
-  "royalblue",
-  "crimson",
-  "darkgreen",
-  "dodgerblue",
-  "darkviolet",
-  "limegreen",
-];
+let colors = ["dodgerblue", "crimson", "seagreen", "darkviolet", "turquoise"];
 const getVictoryGroup = (data, i) => {
   return (
     <VictoryGroup color={colors[i] || "darkgray"} data={dataAsXy(data)}>
@@ -76,6 +82,18 @@ const getVictoryGroup = (data, i) => {
 };
 
 export const HistoryChart: React.FC<Props> = ({ question, history }) => {
+  let height = 400;
+  let width = 500;
+  let dataSetsNames = ["Yes", "No", "Maybe", "Perhaps", "Possibly"];
+  let dataSets = [
+    buildDataset(50, (x) => 0.5),
+    buildDataset(50, (x) => Math.abs(Math.sin((5 * x) / 50) / 2)),
+    buildDataset(50, (x) => 1 - Math.abs(Math.sin((5 * x) / 50) / 2)),
+    buildDataset(50, (x) => Math.abs(Math.sin((3 * x + 25) / 50))),
+    buildDataset(50, (x) => 1 - Math.abs(Math.sin((3 * x + 25) / 50))),
+  ];
+  let dataSetsLength = dataSets.length;
+
   return (
     <div className="grid grid-rows-1 bg-white p-10">
       <a
@@ -89,10 +107,10 @@ export const HistoryChart: React.FC<Props> = ({ question, history }) => {
       </a>
       <VictoryChart
         domainPadding={20}
-        padding={{ top: 20, bottom: 50, left: 50, right: 50 }}
+        padding={{ top: 20, bottom: 50, left: 50, right: 100 }}
         theme={VictoryTheme.material}
-        height={340}
-        width={500}
+        height={height}
+        width={width}
         containerComponent={
           <VictoryVoronoiContainer
             labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
@@ -124,9 +142,26 @@ export const HistoryChart: React.FC<Props> = ({ question, history }) => {
           y: [0, 1],
         }}
       >
-        {[data, data2]
-          .slice(0, 5)
-          .map((dataset, i) => getVictoryGroup(dataset, i))}
+        <VictoryLegend
+          x={width - 100}
+          y={height / 2 - 18 - (dataSetsLength - 1) * 13}
+          orientation="vertical"
+          gutter={20}
+          style={{ border: { stroke: "black" }, title: { fontSize: 20 } }}
+          data={
+            Array.from(Array(dataSetsLength).keys()).map((i) => ({
+              name: dataSetsNames[i],
+              symbol: { fill: colors[i] },
+            }))
+            /*[
+            { name: "One", symbol: { fill: "tomato", type: "star" } },
+            { name: "Two", symbol: { fill: "orange" } },
+            { name: "Three", symbol: { fill: "gold" } },
+          ]*/
+          }
+        />
+
+        {dataSets.slice(0, 5).map((dataset, i) => getVictoryGroup(dataset, i))}
         <VictoryAxis
           // tickValues specifies both the number of ticks and where
           // they are placed on the axis

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+
+import { FrontendForecast } from "../platforms";
+import * as V from "victory";
+import {
+  VictoryBar,
+  VictoryLabel,
+  VictoryTooltip,
+  VictoryLine,
+  VictoryScatter,
+  VictoryChart,
+  VictoryTheme,
+  VictoryAxis,
+  VictoryGroup,
+  VictoryVoronoiContainer,
+} from "victory";
+
+interface Props {
+  question: FrontendForecast;
+  history: number[];
+}
+
+const data = [
+  { date: 1, probability: 0.1 },
+  { date: 2, probability: 0.2 },
+  { date: 3, probability: 0.4 },
+  { date: 4, probability: 0.6 },
+  { date: 5, probability: 0.6 },
+  { date: 6, probability: 0.65 },
+  { date: 7, probability: 0.65 },
+  { date: 8, probability: 0.65 },
+  { date: 9, probability: 0.7 },
+];
+
+let getDate = (x) => {
+  let date = new Date(x);
+  return date.toISOString().slice(5, 10).replaceAll("-", "/");
+};
+
+let dataAsXy = data.map((datum) => ({
+  x: getDate(datum.date * (1000 * 60 * 60 * 24)),
+  y: datum.probability,
+}));
+
+export const HistoryChart: React.FC<Props> = ({ question, history }) => {
+  return (
+    <VictoryChart
+      domainPadding={20}
+      theme={VictoryTheme.material}
+      height={300}
+      containerComponent={<VictoryVoronoiContainer />}
+      domain={{
+        y: [0, 1],
+      }}
+    >
+      <VictoryGroup
+        color="#c43a31"
+        data={dataAsXy}
+        labels={({ datum }) => `${datum.y * 100}%`}
+        labelComponent={
+          <VictoryTooltip style={{ fontSize: 10, fill: "black" }} />
+        }
+      >
+        <VictoryLine />
+        <VictoryScatter size={({ active }) => (active ? 8 : 3)} />
+      </VictoryGroup>
+      <VictoryAxis
+        // tickValues specifies both the number of ticks and where
+        // they are placed on the axis
+        tickValues={data.map((datum) => datum.date)}
+        tickFormat={dataAsXy.map((datum) => datum.x)}
+        style={{
+          grid: { stroke: null, strokeWidth: 0.5 },
+        }}
+        tickLabelComponent={
+          <VictoryLabel
+            dy={0}
+            angle={-30}
+            style={{ fontSize: 7, fill: "gray" }}
+          />
+        }
+      />
+      <VictoryAxis
+        dependentAxis
+        // tickFormat specifies how ticks should be displayed
+        tickFormat={(x) => `${x * 100}%`}
+        style={{
+          grid: { stroke: "#D3D3D3", strokeWidth: 0.5 },
+        }}
+      />
+    </VictoryChart>
+  );
+};
+
+/*
+    <VictoryChart
+      // domainPadding will add space to each side of VictoryBar to
+      // prevent it from overlapping the axis
+      domainPadding={20}
+      theme={VictoryTheme.material}
+      height={300}
+      title={"Blah"}
+      containerComponent={<VictoryVoronoiContainer />}
+    >
+      <VictoryGroup
+        data={data.map((datum) => ({ x: datum.date, y: datum.probability }))}
+        labels={data.map((datum) => `1%`)}
+        style={{ labels: { fill: "black", fontSize: 10 } }}
+        labelComponent={
+          <VictoryTooltip style={{ fontSize: 10, fill: "black" }} dy={-15} />
+        }
+      >
+        <VictoryLine
+          height={300}
+          width={300}
+          style={{
+            data: { stroke: "#000080" },
+            parent: { border: "1px solid #ccc" },
+          }}
+          domain={{
+            y: [0, 1],
+          }}
+        ></VictoryLine>
+        <VictoryScatter
+          style={{
+            data: { fill: "#000080" },
+          }}
+          size={3}
+        />
+      </VictoryGroup>
+    </VictoryChart>
+*/

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -62,21 +62,21 @@ const colors = ["dodgerblue", "crimson", "seagreen", "darkviolet", "turquoise"];
 const getVictoryGroup = (data, i) => {
   return (
     <VictoryGroup color={colors[i] || "darkgray"} data={dataAsXy(data)}>
-      <VictoryLine
-        name={`line${i}`}
+      <VictoryScatter
         //style={{ labels: { display: "none" } }}
+        size={({ active }) => (active ? 3.75 : 3)}
         //labels={() => null}
         //labelComponent={<span></span>}
       />
-      {
-        <VictoryScatter
+
+      {/* Doesn't work well with tooltips
+        <VictoryLine
+          name={`line${i}`}
           //style={{ labels: { display: "none" } }}
-          size={({ active }) => (active ? 3.75 : 3)}
           //labels={() => null}
           //labelComponent={<span></span>}
         />
-        // No idea how to disable labels
-      }
+        */}
     </VictoryGroup>
   );
 };

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { FrontendForecast } from "../platforms";
 import * as V from "victory";
-import { HistoryChartFlyout } from "./HistoryChartFlyout";
 import {
   VictoryBar,
   VictoryLabel,
@@ -15,23 +14,14 @@ import {
   VictoryGroup,
   VictoryVoronoiContainer,
 } from "victory";
+import ReactMarkdown from "react-markdown";
+import { cleanText } from "../utils";
+import gfm from "remark-gfm";
 
 interface Props {
   question: FrontendForecast;
   history: number[];
 }
-
-const data0 = [
-  { date: 1, probability: 0.1 },
-  { date: 2, probability: 0.2 },
-  { date: 3, probability: 0.4 },
-  { date: 4, probability: 0.6 },
-  { date: 5, probability: 0.6 },
-  { date: 6, probability: 0.65 },
-  { date: 7, probability: 0.65 },
-  { date: 8, probability: 0.65 },
-  { date: 9, probability: 0.7 },
-];
 
 let l = 50;
 const data = Array.from(Array(l).keys()).map((x) => ({
@@ -39,62 +29,104 @@ const data = Array.from(Array(l).keys()).map((x) => ({
   probability: Math.abs(Math.sin((5 * x) / l)),
 }));
 
+const data2 = Array.from(Array(l).keys()).map((x) => ({
+  date: x,
+  probability: 1 - Math.abs(Math.sin((5 * x) / l)),
+}));
+
 let getDate = (x) => {
   let date = new Date(x);
   return date.toISOString().slice(5, 10).replaceAll("-", "/");
 };
 
-let dataAsXy = data.map((datum) => ({
-  x: getDate(datum.date * (1000 * 60 * 60 * 24)),
-  y: datum.probability,
-}));
+let dataAsXy = (data) =>
+  data.map((datum) => ({
+    x: getDate(datum.date * (1000 * 60 * 60 * 24)),
+    y: datum.probability,
+  }));
+
+let colors = [
+  "royalblue",
+  "crimson",
+  "darkgreen",
+  "dodgerblue",
+  "darkviolet",
+  "limegreen",
+];
+const getVictoryGroup = (data, i) => {
+  return (
+    <VictoryGroup color={colors[i] || "darkgray"} data={dataAsXy(data)}>
+      <VictoryLine
+        name={`line${i}`}
+        style={{ labels: { display: "none" } }}
+        labels={() => null}
+        labelComponent={<span></span>}
+      />
+      {
+        <VictoryScatter
+          style={{ labels: { display: "none" } }}
+          size={({ active }) => (active ? 3.75 : 3)}
+          labels={() => null}
+          labelComponent={<span></span>}
+        />
+        // No idea how to disable labels
+      }
+    </VictoryGroup>
+  );
+};
 
 export const HistoryChart: React.FC<Props> = ({ question, history }) => {
   return (
-    <div className="">
+    <div className="grid grid-rows-1 bg-white p-10">
+      <a
+        className="text‑inherit no-underline"
+        href={question.url}
+        target="_blank"
+      >
+        <h1 className="text-3xl font-normal text-center mt-5">
+          {question.title}
+        </h1>
+      </a>
       <VictoryChart
         domainPadding={20}
+        padding={{ top: 20, bottom: 50, left: 50, right: 50 }}
         theme={VictoryTheme.material}
-        height={400}
+        height={340}
         width={500}
-        containerComponent={<VictoryVoronoiContainer />}
+        containerComponent={
+          <VictoryVoronoiContainer
+            labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
+            labelComponent={
+              <VictoryTooltip
+                pointerLength={0}
+                dy={-12}
+                style={{
+                  fontSize: 10,
+                  fill: "black",
+                  strokeWidth: 0.05,
+                }}
+                flyoutStyle={{
+                  stroke: "black",
+                  fill: "white",
+                }}
+                flyoutWidth={80}
+                cornerRadius={0}
+                flyoutPadding={7}
+              />
+            }
+            voronoiBlacklist={
+              Array.from(Array(5).keys()).map((x, i) => `line${i}`)
+              // see: https://github.com/FormidableLabs/victory/issues/545
+            }
+          />
+        }
         domain={{
           y: [0, 1],
         }}
       >
-        <VictoryLabel
-          text="Chart Title"
-          x={250}
-          y={25}
-          textAnchor="middle"
-          style={{ fontSize: 20 }}
-        />
-        <VictoryGroup
-          color="darkblue"
-          data={dataAsXy}
-          labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
-          labelComponent={
-            <VictoryTooltip
-              pointerLength={0}
-              dy={-12}
-              style={{
-                fontSize: 16,
-                fill: "black",
-                strokeWidth: 0.05,
-              }}
-              flyoutStyle={{
-                stroke: "black",
-                fill: "white",
-              }}
-              flyoutWidth={110}
-              cornerRadius={0}
-              flyoutPadding={7}
-            />
-          }
-        >
-          <VictoryLine />
-          <VictoryScatter size={({ active }) => (active ? 3.75 : 3)} />
-        </VictoryGroup>
+        {[data, data2]
+          .slice(0, 5)
+          .map((dataset, i) => getVictoryGroup(dataset, i))}
         <VictoryAxis
           // tickValues specifies both the number of ticks and where
           // they are placed on the axis
@@ -108,7 +140,7 @@ export const HistoryChart: React.FC<Props> = ({ question, history }) => {
             <VictoryLabel
               dy={0}
               angle={-30}
-              style={{ fontSize: 12, fill: "gray" }}
+              style={{ fontSize: 10, fill: "gray" }}
             />
           }
         />
@@ -120,10 +152,16 @@ export const HistoryChart: React.FC<Props> = ({ question, history }) => {
             grid: { stroke: "#D3D3D3", strokeWidth: 0.5 },
           }}
           tickLabelComponent={
-            <VictoryLabel dy={0} style={{ fontSize: 12, fill: "gray" }} />
+            <VictoryLabel dy={0} style={{ fontSize: 10, fill: "gray" }} />
           }
         />
       </VictoryChart>
+
+      <ReactMarkdown
+        remarkPlugins={[gfm]}
+        children={question.description}
+        className="m-5 text-lg"
+      />
     </div>
   );
 };

--- a/src/web/display/HistoryChart.tsx
+++ b/src/web/display/HistoryChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { FrontendForecast } from "../platforms";
 import * as V from "victory";
+import { HistoryChartFlyout } from "./HistoryChartFlyout";
 import {
   VictoryBar,
   VictoryLabel,
@@ -20,7 +21,7 @@ interface Props {
   history: number[];
 }
 
-const data = [
+const data0 = [
   { date: 1, probability: 0.1 },
   { date: 2, probability: 0.2 },
   { date: 3, probability: 0.4 },
@@ -31,6 +32,12 @@ const data = [
   { date: 8, probability: 0.65 },
   { date: 9, probability: 0.7 },
 ];
+
+let l = 5;
+const data = Array.from(Array(l).keys()).map((x) => ({
+  date: x,
+  probability: x / l,
+}));
 
 let getDate = (x) => {
   let date = new Date(x);
@@ -54,20 +61,36 @@ export const HistoryChart: React.FC<Props> = ({ question, history }) => {
       }}
     >
       <VictoryGroup
-        color="#c43a31"
+        color="darkblue"
         data={dataAsXy}
-        labels={({ datum }) => `${datum.y * 100}%`}
+        labels={({ datum }) => `${datum.x}: ${Math.round(datum.y * 100)}%`}
         labelComponent={
-          <VictoryTooltip style={{ fontSize: 10, fill: "black" }} />
+          <VictoryTooltip
+            pointerLength={0}
+            dy={-12}
+            style={{
+              fontSize: 9,
+              fill: "black",
+              strokeWidth: 0.05,
+            }}
+            flyoutStyle={{
+              stroke: "black",
+              fill: "white",
+            }}
+            flyoutWidth={60}
+            cornerRadius={0}
+            flyoutPadding={7}
+          />
         }
       >
         <VictoryLine />
-        <VictoryScatter size={({ active }) => (active ? 8 : 3)} />
+        <VictoryScatter size={({ active }) => (active ? 3.75 : 3)} />
       </VictoryGroup>
       <VictoryAxis
         // tickValues specifies both the number of ticks and where
         // they are placed on the axis
         tickValues={data.map((datum) => datum.date)}
+        tickCount={10}
         tickFormat={dataAsXy.map((datum) => datum.x)}
         style={{
           grid: { stroke: null, strokeWidth: 0.5 },

--- a/src/web/display/HistoryChartFlyout.tsx
+++ b/src/web/display/HistoryChartFlyout.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const HistoryChartFlyout = ({ x, y, datum, dx, dy }) => {
+  return <div>{x}</div>;
+};

--- a/src/web/display/HistoryChartFlyout.tsx
+++ b/src/web/display/HistoryChartFlyout.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export const HistoryChartFlyout = ({ x, y, datum, dx, dy }) => {
-  return <div>{x}</div>;
-};

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -9,3 +9,21 @@ export const reqToBasePath = (req: IncomingMessage) => {
   // we could just hardcode http://localhost:3000 here, but then `next dev -p <CUSTOM_PORT>` would break
   return "http://" + req.headers.host;
 };
+
+export const cleanText = (text: string): string => {
+  // Note: should no longer be necessary
+  let textString = !!text ? text : "";
+  textString = textString
+    .replaceAll("] (", "](")
+    .replaceAll(") )", "))")
+    .replaceAll("( [", "([")
+    .replaceAll(") ,", "),")
+    .replaceAll("==", "") // Denotes a title in markdown
+    .replaceAll("Background\n", "")
+    .replaceAll("Context\n", "")
+    .replaceAll("--- \n", "- ")
+    .replaceAll(/\[(.*?)\]\(.*?\)/g, "$1");
+  textString = textString.slice(0, 1) == "=" ? textString.slice(1) : textString;
+  //console.log(textString)
+  return textString;
+};


### PR DESCRIPTION
This branch adds charts. It is a work in progress, and thus not ready to be merged.
![chart2](https://user-images.githubusercontent.com/16527456/164360480-9bf6613a-946c-4bc9-8b57-5157291c452a.png)

To do:
- [ ] Use real rather than fake data. I'm hoping the graphql interface can be used for this, rather than having to interact with it directly
- [ ] Reduce the chart size. Take https://manifold.markets/ or https://polymarket.com/ as reference points
  - As a sidenote, I think I'm accustomed to much bigger fonts than normal, so my personal preference shouldn't really be a guiding factor here.
- [ ] Add functionality so that charts can be embedded
- [ ] Only display the yes in the case of a binary question
- [ ] Add the ability to combine many questions at once, maybe with shorthand labels in the url query
- [ ] Add bells and whistles: Different options, allow one to consider different time periods, show quality indicators, add zoom ability, add other functionality in https://polymarket.com (they recently did a really nice chart refactoring)
- [ ] Incorporate some feedback from [twitter](https://twitter.com/NunoSempere/status/1516763181489737729), and generally from @ClayGraubard or @uvafan 
- [ ] Embed into EA Forum/LessWrong

Overall my sense is that these are already better than Metaculus/CultivateLabs charts. I think we should be aiming to be at least as nice as Manifold Markets or https://globalguessing.com/russia-ukraine-forecasts/, e.g., nice enough that the Global Guessing team replaces their current charts with ours.

My sense is that @berekuk might particularly enjoy integrating this with EA Forum/LessWrong. Ideally, you @berekuk might also be up for helping out with this or directly take over after finishing with the grapqhl api, but I'm also up for working on this more slowly.