### PR TITLE
Fix for frontpage table refactoring

### DIFF
--- a/src/backend/database/prisma.ts
+++ b/src/backend/database/prisma.ts
@@ -3,13 +3,13 @@ import { PrismaClient } from "@prisma/client";
 declare global {
   // allow global `var` declarations
   // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined;
+  var _prisma: PrismaClient | undefined;
 }
 
 export const prisma =
-  global.prisma ||
+  global._prisma ||
   new PrismaClient({
     log: ["query"],
   });
 
-if (process.env.NODE_ENV !== "production") global.prisma = prisma;
+if (process.env.NODE_ENV !== "production") global._prisma = prisma;

--- a/src/backend/frontpage.ts
+++ b/src/backend/frontpage.ts
@@ -3,14 +3,13 @@ import { Question } from "@prisma/client";
 import { measureTime } from "./utils/measureTime";
 
 export async function getFrontpage(): Promise<Question[]> {
-  const questions = await prisma.question.findMany({
-    where: {
-      onFrontpage: {
-        isNot: null,
+  const questions = (
+    await prisma.frontpageId.findMany({
+      include: {
+        question: true,
       },
-    },
-  });
-  console.log(questions.length);
+    })
+  ).map((f) => f.question);
   return questions;
 }
 

--- a/src/backend/frontpage.ts
+++ b/src/backend/frontpage.ts
@@ -1,5 +1,6 @@
 import { Question } from "@prisma/client";
 
+import { prisma } from "./database/prisma";
 import { measureTime } from "./utils/measureTime";
 
 export async function getFrontpage(): Promise<Question[]> {

--- a/src/backend/frontpage.ts
+++ b/src/backend/frontpage.ts
@@ -9,7 +9,9 @@ export async function getFrontpage(): Promise<Question[]> {
         question: true,
       },
     })
-  ).map((f) => f.question);
+  )
+    .map((f) => f.question)
+    .filter((q) => q);
   return questions;
 }
 

--- a/src/graphql/schema/frontpage.ts
+++ b/src/graphql/schema/frontpage.ts
@@ -7,7 +7,12 @@ builder.queryField("frontpage", (t) =>
     type: [QuestionObj],
     description: "Get a list of questions that are currently on the frontpage",
     resolve: async () => {
-      return await getFrontpage();
+      try {
+        return await getFrontpage();
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
     },
   })
 );

--- a/src/graphql/schema/frontpage.ts
+++ b/src/graphql/schema/frontpage.ts
@@ -7,12 +7,7 @@ builder.queryField("frontpage", (t) =>
     type: [QuestionObj],
     description: "Get a list of questions that are currently on the frontpage",
     resolve: async () => {
-      try {
-        return await getFrontpage();
-      } catch (e) {
-        console.error(e);
-        throw e;
-      }
+      return await getFrontpage();
     },
   })
 );


### PR DESCRIPTION
(continuing from #67, turns out GH doesn't allow reopening PRs...)

Ok, I'm not sure what happened, but #67 broke prod. I'm opening this just to leave this postmortem note, and to check the code before merging to master.

My original approach went like this:

```typescript
  const questions = await prisma.frontpageId.findMany({
    include: {
      question: true,
    }
  });
```

Prisma generated a weird query, which I noticed but decided that it's not a big deal (notice the triple negations):

```
SELECT "public"."questions"."id", "public"."questions"."title", "public"."questions"."url", "public"."questions"."platform", "public"."questions"."description", "public"."questions"."options", "public"."questions"."timestamp", "public"."questions"."stars", "public"."questions"."qualityindicators", "public"."questions"."extra" FROM "public"."questions" WHERE (NOT ("public"."questions"."id") NOT IN (SELECT "public"."FrontpageId"."id" FROM "public"."FrontpageId" WHERE "public"."FrontpageId"."id" IS NOT NULL)) OFFSET $1
```

It worked on my machine for my local dev db but collapsed in prod.

Anyway, when I went to debug it I noticed that it also wasn't keeping the random order because I selected _questions_ which had _frontpage ids_, which sorted the questions in the natural questions order.

So now I'm doing it in reverse: select for frontpage ids and ask Prisma to add questions data to it.

This causes two queries instead of one:

```
prisma:query SELECT "public"."FrontpageId"."id" FROM "public"."FrontpageId" WHERE 1=1 OFFSET $1
prisma:query SELECT "public"."questions"."id", "public"."questions"."title", "public"."questions"."url", "public"."questions"."platform", "public"."questions"."description", "public"."questions"."options", "public"."questions"."timestamp", "public"."questions"."stars", "public"."questions"."qualityindicators", "public"."questions"."extra" FROM "public"."questions" WHERE "public"."questions"."id" IN ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46,$47,$48,$49,$50) OFFSET $51
```

But it shouldn't be a problem.