### PR TITLE
Incremental fetchers

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,3 +93,14 @@ model FrontpageId {
   question Question @relation(fields: [id], references: [id], onDelete: Cascade)
   id       String   @unique
 }
+
+model Robot {
+  id        Int       @id @default(autoincrement())
+  platform  String
+  url       String // non-unique, rescheduling always creates a new row
+  context   Json
+  created   DateTime  @db.Timestamp(6)
+  scheduled DateTime  @db.Timestamp(6) // can be equal to `created` or can be in the future for rescheduling or other purposes
+  completed DateTime? @db.Timestamp(6) // becomes non-null when the job is done
+  tried     Int       @default(0) // used to set a limit on max attempts for badly written platforms
+}

--- a/src/backend/platforms/metaculus/index.ts
+++ b/src/backend/platforms/metaculus/index.ts
@@ -1,36 +1,43 @@
 import { FetchedQuestion, Platform } from "..";
 import { average } from "../../../utils";
-import { sleep } from "../../utils/sleep";
+import { Robot, RobotJob } from "../../robot";
 import {
   ApiCommon,
-  ApiMultipleQuestions,
   ApiPredictable,
   ApiQuestion,
-  fetchApiQuestions,
-  fetchSingleApiQuestion,
+  prepareApiQuestions,
+  prepareSingleApiQuestion,
 } from "./api";
 
 const platformName = "metaculus";
 const now = new Date().toISOString();
 const SLEEP_TIME = 1000;
 
-async function apiQuestionToFetchedQuestions(
+type Context =
+  | {
+      type: "apiIndex";
+    }
+  | {
+      type: "apiQuestion";
+    };
+
+const skip = (q: ApiPredictable): boolean => {
+  if (q.publish_time > now || now > q.resolve_time) {
+    return true;
+  }
+  if (q.number_of_predictions < 10) {
+    return true;
+  }
+  return false;
+};
+
+async function processApiQuestion(
   apiQuestion: ApiQuestion
 ): Promise<FetchedQuestion[]> {
   // one item can expand:
   // - to 0 questions if we don't want it;
   // - to 1 question if it's a simple forecast
   // - to multiple questions if it's a group (see https://github.com/quantified-uncertainty/metaforecast/pull/84 for details)
-
-  const skip = (q: ApiPredictable): boolean => {
-    if (q.publish_time > now || now > q.resolve_time) {
-      return true;
-    }
-    if (q.number_of_predictions < 10) {
-      return true;
-    }
-    return false;
-  };
 
   const buildFetchedQuestion = (
     q: ApiPredictable & ApiCommon
@@ -72,19 +79,14 @@ async function apiQuestionToFetchedQuestions(
   };
 
   if (apiQuestion.type === "group") {
-    await sleep(SLEEP_TIME);
-    const apiQuestionDetails = await fetchSingleApiQuestion(apiQuestion.id);
-    if (apiQuestionDetails.type !== "group") {
-      throw new Error("Expected `group` type"); // shouldn't happen, this is mostly for typescript
-    }
-    return (apiQuestionDetails.sub_questions || [])
+    return (apiQuestion.sub_questions || [])
       .filter((q) => !skip(q))
       .map((sq) => {
         const tmp = buildFetchedQuestion(sq);
         return {
           ...tmp,
           title: `${apiQuestion.title} (${sq.title})`,
-          description: apiQuestionDetails.description || "",
+          description: apiQuestion.description || "",
           url: `https://www.metaculus.com${apiQuestion.page_url}?sub-question=${sq.id}`,
         };
       });
@@ -96,81 +98,90 @@ async function apiQuestionToFetchedQuestions(
       return [];
     }
 
-    await sleep(SLEEP_TIME);
-    const apiQuestionDetails = await fetchSingleApiQuestion(apiQuestion.id);
     const tmp = buildFetchedQuestion(apiQuestion);
     return [
       {
         ...tmp,
         title: apiQuestion.title,
-        description: apiQuestionDetails.description || "",
+        description: apiQuestion.description || "",
         url: "https://www.metaculus.com" + apiQuestion.page_url,
       },
     ];
   } else {
-    if (apiQuestion.type !== "claim") {
-      // should never happen, since `discriminator` in JTD schema causes a strict runtime check
-      console.log(
-        `Unknown metaculus question type: ${
-          (apiQuestion as any).type
-        }, skipping`
-      );
-    }
+    console.log(
+      `Unknown metaculus question type: ${apiQuestion.type}, skipping`
+    );
     return [];
   }
 }
 
-export const metaculus: Platform<"id" | "debug"> = {
+async function processApiIndexQuestion(
+  apiQuestion: ApiQuestion,
+  robot: Robot<Context>
+): Promise<void> {
+  if (apiQuestion.type === "group" || apiQuestion.type === "forecast") {
+    if (apiQuestion.type === "forecast" && skip(apiQuestion)) {
+      return;
+    }
+    await robot.schedule({
+      url: `https://www.metaculus.com/api2/questions/${apiQuestion.id}/`,
+      context: {
+        type: "apiQuestion",
+      },
+    });
+  }
+}
+
+export const metaculus: Platform<"id" | "debug", Context> = {
   name: platformName,
   label: "Metaculus",
   color: "#006669",
-  version: "v2",
+  version: "v3",
   fetcherArgs: ["id", "debug"],
-  async fetcher(opts) {
-    let allQuestions: FetchedQuestion[] = [];
+  async fetcher({ robot, storage }) {
+    await robot.schedule({
+      url: "https://www.metaculus.com/api2/questions/",
+      context: {
+        type: "apiIndex",
+      },
+    });
 
-    if (opts.args?.id) {
-      const id = Number(opts.args.id);
-      const apiQuestion = await fetchSingleApiQuestion(id);
-      const questions = await apiQuestionToFetchedQuestions(apiQuestion);
-      console.log(questions);
-      return {
-        questions,
-        partial: true,
-      };
-    }
+    for (
+      let job: RobotJob<Context> | undefined;
+      (job = await robot.nextJob());
 
-    let next: string | null = "https://www.metaculus.com/api2/questions/";
-    let i = 1;
-    while (next) {
-      console.log(`\nQuery #${i} - ${next}`);
+    ) {
+      const data = await job.fetch();
 
-      await sleep(SLEEP_TIME);
-      const apiQuestions: ApiMultipleQuestions = await fetchApiQuestions(next);
-      const results = apiQuestions.results;
-
-      let j = false;
-
-      for (const result of results) {
-        const questions = await apiQuestionToFetchedQuestions(result);
-        for (const question of questions) {
-          console.log(`- ${question.title}`);
-          if ((!j && i % 20 === 0) || opts.args?.debug) {
-            console.log(question);
-            j = true;
-          }
-          allQuestions.push(question);
+      if (job.context.type === "apiIndex") {
+        const apiIndex = await prepareApiQuestions(data);
+        if (apiIndex.next) {
+          await robot.schedule({
+            url: apiIndex.next,
+            context: {
+              type: "apiIndex",
+            },
+          });
         }
+
+        for (const apiQuestion of apiIndex.results) {
+          await processApiIndexQuestion(apiQuestion, robot);
+          // for (const question of questions) {
+          //   console.log(`- ${question.title}`);
+          //   allQuestions.push(question);
+          // }
+        }
+      } else if (job.context.type === "apiQuestion") {
+        const apiQuestion = await prepareSingleApiQuestion(data);
+        const fetchedQuestions = await processApiQuestion(apiQuestion);
+        for (const q of fetchedQuestions) {
+          await storage.upsert(q);
+        }
+      } else {
+        console.warn(`Unknown context type ${(job.context as any).type}`);
       }
-
-      next = apiQuestions.next;
-      i += 1;
+      await job.done();
     }
-
-    return {
-      questions: allQuestions,
-      partial: false,
-    };
   },
 
   calculateStars(data) {

--- a/src/backend/platforms/registry.ts
+++ b/src/backend/platforms/registry.ts
@@ -18,7 +18,7 @@ import { wildeford } from "./wildeford";
 import { xrisk } from "./xrisk";
 
 // function instead of const array, this helps to fight circular dependencies
-export const getPlatforms = (): Platform<string>[] => {
+export const getPlatforms = (): Platform<string, any>[] => {
   return [
     betfair,
     fantasyscotus,

--- a/src/backend/robot/index.ts
+++ b/src/backend/robot/index.ts
@@ -1,0 +1,82 @@
+import axios from "axios";
+import { prisma } from "../database/prisma";
+import { Platform } from "../platforms";
+
+// type Context = Prisma.JsonObject; // untyped for now, might become a generic in the future
+
+export type RobotJob<Context> = {
+  context: Context;
+  fetch: () => Promise<unknown>;
+  done: () => Promise<void>;
+};
+
+export type Robot<Context> = {
+  nextJob: () => Promise<RobotJob<Context> | undefined>;
+  schedule: (args: { url: string; context?: Context }) => Promise<void>;
+};
+
+export const getRobot = <Context>(
+  platform: Platform<any, Context>
+): Robot<Context> => {
+  return {
+    async nextJob() {
+      const jobData = await prisma.robot.findFirst({
+        where: {
+          platform: platform.name,
+          completed: {
+            equals: null,
+          },
+          scheduled: {
+            lte: new Date(),
+          },
+        },
+        orderBy: {
+          created: "asc",
+        },
+      });
+      if (!jobData) {
+        return;
+      }
+      await prisma.robot.update({
+        where: {
+          id: jobData?.id,
+        },
+        data: {
+          tried: jobData.tried + 1,
+        },
+      });
+
+      const job: RobotJob<Context> = {
+        context: jobData.context as Context,
+        async fetch() {
+          const data = await axios.get(jobData.url);
+          return data.data;
+        },
+        async done() {
+          await prisma.robot.update({
+            where: {
+              id: jobData.id,
+            },
+            data: {
+              completed: new Date(),
+            },
+          });
+        },
+      };
+      return job;
+    },
+
+    async schedule({ url, context = {} }) {
+      const now = new Date();
+      await prisma.robot.create({
+        data: {
+          url,
+          platform: platform.name,
+          created: now,
+          scheduled: now,
+          context,
+        },
+      });
+    },
+  };
+};

--- a/src/backend/robot/index.ts
+++ b/src/backend/robot/index.ts
@@ -68,15 +68,39 @@ export const getRobot = <Context>(
 
     async schedule({ url, context = {} }) {
       const now = new Date();
-      await prisma.robot.create({
-        data: {
-          url,
+
+      const oldJob = await prisma.robot.findFirst({
+        where: {
           platform: platform.name,
-          created: now,
-          scheduled: now,
-          context,
+          url,
+          completed: {
+            equals: null,
+          },
         },
       });
+
+      if (oldJob) {
+        await prisma.robot.update({
+          where: {
+            id: oldJob.id,
+          },
+          data: {
+            created: now,
+            scheduled: now,
+            context,
+          },
+        });
+      } else {
+        await prisma.robot.create({
+          data: {
+            url,
+            platform: platform.name,
+            created: now,
+            scheduled: now,
+            context,
+          },
+        });
+      }
     },
   };
 };


### PR DESCRIPTION
This is a draft for #35 and #36, and it's not ready yet, but the changes are significant and I want to braindump my thoughts on it.

So, currently all platform modules fetch all questions and then store a huge array in the DB (and then on Algolia).

As I mentioned in #36, I'd like to change that.

---

Sidenote: I spent several hours today fighting the new metaculus fetcher which failed for one reason or another (mostly because of excessive validation, but also once because one question was on the frontpage and `ON DELETE` was set to restrict instead of cascade). Every time I had to wait until it got past the last point of failure, only to have it fail again further down the road.

I really don't like to have such a long feedback loop to get some initial results; also, the current architecture gets in the way when I want to get _some_ questions in my dev DB. Though I've recently implemented the `npm run cli metaculus -- --id=12345` command, what I really want is to say "fetch some stuff for this platform" without waiting several hours for the script to finish.

Of course, there are also other benefits for why I'm doing this; getting us closer to the real-time capabilities, etc.

---

The basic idea is: we crawl the graph of urls; there are some leaf nodes (question page urls or graphql endpoints with questions data or whatever) and some intermediate nodes which allow us to discover leaf nodes, e.g. `/api2/questions/` on metaculus which doesn't give us full data but gives it us urls for other api pages with full data.

To store the progress we can use the table (`Robot`) with jobs as rows; each job includes an url, a json context, and some metadata for when the job was created and whether it was completed. Then we can encapsulate the common pattern of "keep fetching stuff until there's some stuff to process" behind a common API.

Here's a draft which uses this approach:

```typescript
export const myPlatform = {
	...,
	async fetcher({ robot, storage }) {
		await robot.schedule({
			url: 'https://www.metaculus.com/api2/questions/',
			context: {
				type: 'apiIndex',
			},
                        maxAge: 3600 * 24, // don't schedule if previous fetch happened recently
		});

		for(let job; job = await robot.nextJob(); ) {
			const result = await job.fetch();
			if (job.context.type === 'apiIndex') {
				const data = validate(result);
				for (const tmp of data) {
					await robot.schedule({
						url: tmp.url,
						context: {
							type: 'apiSingle',
						},
					});
				}
				if (data.next) {
					await robot.schedule({
						url: data.next,
						context: {
							type: 'apiIndex',
						},
					});
				}
			} else if (job.context.type === 'apiSingle') {
				const validated = validate(result);
				const question = resultToQuestion(validated);
				await storage.save(question);

                                // complete the job and create a new one; this is excessive in this case since we crawl the index api pages, but can be helpful in other cases
				await job.done({ repeatAfter: 86400 });
			} else {
				throw new Error("Unknown job type");
			}
		}
	}
};
```

Notes on this example:
- fetcher don't return anything, it calls `storage.save` instead
- fetcher is completely interruptible, you should be able to ctrl+c it and restart it and it'll continue from the same point
- fetcher exits when there are no jobs queued up but you can just restart it every minute and it'll queue up new stuff when it becomes necessary (previous discussion: #35)
- fetcher could add different indices to the queue with the different `maxAge` values; e.g., it's easy to schedule a metaculus frontpage with a small `maxAge` and crawl urls from it more frequently
- robot API could encapsulate sleeps and other common logic (not implemented yet)
- `storage.save` will also update history and algolia synchronously, no need to do it in a separate step

In the future, we could also:
- separate the robot and the platform code further, so that it'll be possible to run "re-process all the fetched data which is already cached"
- pass a different storage to the fetcher, e.g. for debugging purposes you could console.log questions instead of storing them in the DB

Stuff I'm still figuring out:
- need to pass platform-specific credentials to the robot somehow
- not sure if `maxAge` and `repeatAfter` is the right approach, still experimenting with this
- need a mode for force-fetching even if url was fetched recently; this can be hacked with `DELETE from "Robot" WHERE platform = "myplatform"`, not sure if we need anything more
- how to deploy this (maybe it's a good time to move away from Heroku to a separate DO instance)
- deletions are problematic (I'll expand on this in a comment)