### PR TITLE
Fix metaculus validation bug

### DIFF
--- a/src/backend/platforms/metaculus/api.ts
+++ b/src/backend/platforms/metaculus/api.ts
@@ -64,6 +64,7 @@ const predictableProps = {
         additionalProperties: true,
       },
     },
+    nullable: true,
     additionalProperties: true,
   },
 } as const;

--- a/src/backend/platforms/metaculus/index.ts
+++ b/src/backend/platforms/metaculus/index.ts
@@ -36,7 +36,7 @@ async function apiQuestionToFetchedQuestions(apiQuestion: ApiQuestion): Promise<
       const isBinary = q.possibilities.type === "binary";
       let options: FetchedQuestion["options"] = [];
       if (isBinary) {
-        const probability = q.community_prediction.full.q2;
+        const probability = q.community_prediction?.full.q2;
         if (probability !== undefined) {
           options = [
             {


### PR DESCRIPTION
`community_prediction` can be null on subquestions.

E.g. https://www.metaculus.com/api2/questions/12663/