### PR TITLE
history.idref index

### DIFF
--- a/prisma/migrations/20230808003420_idref_index/migration.sql
+++ b/prisma/migrations/20230808003420_idref_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "history_idref_idx" ON "history"("idref");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,7 @@ model History {
   @@index([id])
   @@index([platform])
   @@index([fetched])
+  @@index([idref])
   @@map("history")
 }
 


### PR DESCRIPTION
Fix for #101.

Turns out neither Postgres or Prisma doesn't create an index on foreign keys, and we did full table scans on all `from history where idref="..."` queries.

I've already applied this migration in prod.